### PR TITLE
Add ComponentDidUpdate Functionality

### DIFF
--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -36,6 +36,10 @@ export default class ScrollBar extends Component {
         });
     }
 
+    componentDidUpdate() {
+        ps.update(this._container);
+    }
+
     componentWillUnmount() {
         // unhook up evens
         Object.keys(this._handlerByEvent).forEach((value, key) => {


### PR DESCRIPTION
The react-perfect-scrollbar works well on initial render, but
if the underlying content changes in size, the scrollbar size
does not update until you manually interact with the scrollbar.
By adding this function, the scrollbar will update any time
the content size changes.