### PR TITLE
Update containerRef function to take 'ref' as param

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ export interface ScrollBarProps {
     /**
      * get the container ref
      */
-    containerRef?: (() => void);
+    containerRef?: ((ref) => void);
 
     /**
      * fires when the y-axis is scrolled in either direction.


### PR DESCRIPTION
Not able to assign ref with `containerRef?: (() => void);`  in index.d.ts.

**Error Generated :** 
```
[ts]
Types of property 'containerRef' are incompatible.
  Type '(_ref: any) => void' is not assignable to type '(() => void) | undefined'.
    Type '(_ref: any) => void' is not assignable to type '() => void'.
```

contaienrRef function is not compatible as it is not taking any params 
`containerRef?: (() => void); `  in index.d.ts

**Solution:**

pass ref as param to containerRef
`containerRef?: ((ref) => void); `  in index.d.ts