### PR TITLE
Unhooking events only if necessary

### DIFF
--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -46,7 +46,7 @@ export default class ScrollBar extends Component {
     if (this._handlerByEvent.size > 0) {
       Object.keys(this._handlerByEvent).forEach((value, key) => {
         this._container.removeEventListener(key, value, false);
-      });  
+      });
     }
     this._handlerByEvent.clear();
     this._ps.destroy();

--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -42,10 +42,12 @@ export default class ScrollBar extends Component {
   }
 
   componentWillUnmount() {
-    // unhook up evens
-    Object.keys(this._handlerByEvent).forEach((value, key) => {
-      this._container.removeEventListener(key, value, false);
-    });
+    // unhook up events
+    if (this._handlerByEvent.size > 0) {
+      Object.keys(this._handlerByEvent).forEach((value, key) => {
+        this._container.removeEventListener(key, value, false);
+      });  
+    }
     this._handlerByEvent.clear();
     this._ps.destroy();
     this._ps = null;


### PR DESCRIPTION
Iterating over the map even when empty was causing the following error in certain conditions:

React: 16.6.0
TypeScript: 3.1.5

(Webpack config)
module: "esnext"
target: "es5"
lib: ["es2015", "dom", "esnext"]

-----------------------------------------------------------------------------------------------------

Uncaught TypeError: Failed to execute 'removeEventListener' on 'EventTarget': The callback provided as parameter 2 is not an object.
    at scrollbar.js:85
    at Array.forEach (<anonymous>)
    at ScrollBar.componentWillUnmount (scrollbar.js:84)
[...]