### PR TITLE
The argument of ref is the actual node

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,7 +30,7 @@ export interface ScrollBarProps {
   /**
    * get the container ref
    */
-  containerRef?: ((ref: React.RefObject<any>) => void);
+  containerRef?: ((container: HTMLElement) => void);
 
   /**
    * fires when the y-axis is scrolled in either direction.


### PR DESCRIPTION
If ref is a function React will call it with the actual DOM element and
not with a RefObject.

See https://reactjs.org/docs/refs-and-the-dom.html#callback-refs