### PR TITLE
feat: add onSync callback to resolve #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ All the callback 'onXXXX' can accept a parameter: the ref to the scrollbar conta
     </PerfectScrollbar>
 ```
 
+#### onSync
+Invoked when `PerfectScrollbar` comp needs to sync the scrollbar container by invoking `ps.update()`(Basically, it is invoked in CDU lifecycle) and receive the internal `perfect-scroll` instance `ps` as parameter.
+
+It is useful when you want to customize the sync logic in some scenarios, eg: debounce the invocation of `ps.update()`.
+
+For more detail, please refer to [issue#87](https://github.com/goldenyz/react-perfect-scrollbar/issues/87) and the example directory.
+
 #### React.HTMLAttributes
 Any attributes defined in [React.HTMLAttributes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1689) can be used for the component.
 

--- a/example/example.js
+++ b/example/example.js
@@ -10,6 +10,14 @@ function logEvent(type) {
   console.log(`event '${type}' triggered!`);
 }
 
+const debounce = (fn, ms = 0) => {
+  let timeoutId;
+  return function wrapper(...args) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  };
+};
+
 class Example extends Component {
   constructor(props) {
     super(props);
@@ -17,6 +25,7 @@ class Example extends Component {
     this.state = {
       className: undefined,
       onXReachEnd: null,
+      items: Array.from(new Array(100).keys()),
     };
   }
 
@@ -33,28 +42,48 @@ class Example extends Component {
     logEvent('onYReachEnd');
   }
 
+  handleTrigger = () => {
+    this.setState({
+      items: Array.from(new Array(100).keys()),
+    });
+  }
+
+  handleSync = debounce((ps) => {
+    ps.update();
+    console.log('debounce sync ps container in 1000ms');
+  }, 1000)
+
   render() {
     const { className, onXReachEnd } = this.state;
 
     return (
-      <div className="example">
-        <ScrollBar
-          className={className}
-          onScrollY={() => logEvent('onScrollY')}
-          onScrollX={() => logEvent('onScrollX')}
-          onScrollUp={() => logEvent('onScrollUp')}
-          onScrollDown={() => logEvent('onScrollDown')}
-          onScrollLeft={() => logEvent('onScrollLeft')}
-          onScrollRight={() => logEvent('onScrollRight')}
-          onYReachStart={() => logEvent('onYReachStart')}
-          onYReachEnd={this.handleYReachEnd}
-          onXReachStart={() => logEvent('onXReachStart')}
-          onXReachEnd={onXReachEnd}
-          component="div"
-        >
-          <div className="content" />
-        </ScrollBar>
-      </div>
+      <React.Fragment>
+
+        <div className="example">
+          <ScrollBar
+            className={className}
+            onScrollY={() => logEvent('onScrollY')}
+            onScrollX={() => logEvent('onScrollX')}
+            onScrollUp={() => logEvent('onScrollUp')}
+            onScrollDown={() => logEvent('onScrollDown')}
+            onScrollLeft={() => logEvent('onScrollLeft')}
+            onScrollRight={() => logEvent('onScrollRight')}
+            onYReachStart={() => logEvent('onYReachStart')}
+            onYReachEnd={this.handleYReachEnd}
+            onXReachStart={() => logEvent('onXReachStart')}
+            onXReachEnd={onXReachEnd}
+            component="div"
+          >
+            <div className="content" />
+          </ScrollBar>
+        </div>
+        <div className="example">
+          <button onClick={this.handleTrigger}>Trigger</button>
+          <ScrollBar onSync={this.handleSync}>
+            {this.state.items.map(e => (<div key={e}>{e}</div>))}
+          </ScrollBar>
+        </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -37,7 +37,9 @@ export default class ScrollBar extends Component {
 
   componentDidUpdate(prevProps) {
     this._updateEventHook(prevProps);
-    this._ps.update();
+
+    if (typeof this.props.onSync === 'function') this.props.onSync(this._ps);
+
     if (prevProps.className !== this.props.className) {
       this._updateClassName();
     }
@@ -89,10 +91,6 @@ export default class ScrollBar extends Component {
     }
   }
 
-  updateScroll() {
-    this._ps.update();
-  }
-
   handleRef(ref) {
     this._container = ref;
     this.props.containerRef(ref);
@@ -116,6 +114,7 @@ export default class ScrollBar extends Component {
       onXReachStart,
       onXReachEnd,
       component,
+      onSync,
       children,
       ...remainProps
     } = this.props;
@@ -145,6 +144,7 @@ ScrollBar.defaultProps = {
   onYReachEnd: undefined,
   onXReachStart: undefined,
   onXReachEnd: undefined,
+  onSync: ps => ps.update(),
   component: 'div',
 };
 
@@ -165,5 +165,6 @@ ScrollBar.propTypes = {
   onYReachEnd: PropTypes.func,
   onXReachStart: PropTypes.func,
   onXReachEnd: PropTypes.func,
+  onSync: PropTypes.func,
   component: PropTypes.string,
 };

--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -38,7 +38,7 @@ export default class ScrollBar extends Component {
   componentDidUpdate(prevProps) {
     this._updateEventHook(prevProps);
 
-    if (typeof this.props.onSync === 'function') this.props.onSync(this._ps);
+    this.updateScroll();
 
     if (prevProps.className !== this.props.className) {
       this._updateClassName();
@@ -92,8 +92,7 @@ export default class ScrollBar extends Component {
   }
 
   updateScroll() {
-    if (typeof this.props.onSync === 'function') this.props.onSync(this._ps);
-    else this._ps.update();
+    this.props.onSync(this._ps);
   }
 
   handleRef(ref) {

--- a/src/scrollbar.js
+++ b/src/scrollbar.js
@@ -91,6 +91,11 @@ export default class ScrollBar extends Component {
     }
   }
 
+  updateScroll() {
+    if (typeof this.props.onSync === 'function') this.props.onSync(this._ps);
+    else this._ps.update();
+  }
+
   handleRef(ref) {
     this._container = ref;
     this.props.containerRef(ref);


### PR DESCRIPTION
## the new behavior
add `onSync` callback to `ScrollBar` comp.

## why
the reason is that I think it is better to decouple the implementation of how to sync perfect-scroll container by invoking `ps.update()` with `DI` pattern. In this way, we don't need to expose several `props` which stand for some special meaning, eg: `debounceUpdate`, `debounceTime`, `debounceMaxTime` and so on. We pass `ps` instance to user and let them decide how to sync the container(even not by involing `ps.update()`).

## how to use it
please refer to `example.js`